### PR TITLE
chore: enable sticky comment for PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Enable sticky comment for Claude Code PR reviews
- Updates existing comment instead of creating duplicates on each push

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed the code
- [x] Tests pass locally