### PR TITLE
fix: update GitHub workflow permissions for PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -45,8 +45,5 @@ jobs:
             - `docs/code-review-guide.md` for review guidelines and output format
             - `CLAUDE.md` for project-specific conventions
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
           # Use Claude Opus 4.5 model with allowed tools for PR review
-          claude_args: '--model claude-opus-4-5 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
+          claude_args: '--model claude-opus-4-5 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -42,4 +42,3 @@ jobs:
 
           # Use Claude Opus 4.5 model
           claude_args: '--model claude-opus-4-5'
-


### PR DESCRIPTION
## Summary
- Change `pull-requests` permission from `read` to `write` in both Claude workflows
- Remove `gh pr comment` from allowed tools (action handles PR comments natively)
- Clean up trailing whitespace

## Test plan
- [ ] Verify Claude code review workflow can post comments on PRs
- [ ] Verify Claude workflow has correct permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)