### PR TITLE
fix: correct claude bot author login to claude[bot]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,7 @@ jobs:
             IMPORTANT - Comment Management:
             There should only be ONE review comment from Claude at any time. Before leaving a comment:
             1. First, check for existing comments using: `gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments`
-            2. Look for any comment where the author login is "github-actions[bot]" or contains "Claude" in the body
+            2. Look for any comment where the author login is "claude[bot]"
             3. If an existing comment is found, UPDATE it using: `gh api repos/${{ github.repository }}/issues/comments/{comment_id} -X PATCH -f body="<new review content>"`
             4. If no existing comment is found, create a new one using: `gh pr comment ${{ github.event.pull_request.number }} --body "<review content>"`
 


### PR DESCRIPTION
## Summary
- Fix the author login check from "github-actions[bot]" to "claude[bot]"
- This ensures existing review comments are properly detected and updated

## Test plan
- [ ] Verify Claude code review workflow correctly identifies existing comments by claude[bot]
- [ ] Verify existing comments are updated instead of creating duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)