### PR TITLE
refactor(ci): unify code review with code-reviewer agent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,12 +37,14 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            Use the code-reviewer agent to review PR #${{ github.event.pull_request.number }}.
 
-            Review this pull request following:
-            - `docs/code-review-guide.md` for review guidelines and output format
-            - `CLAUDE.md` for project-specific conventions
+            First, get the PR diff:
+            ```
+            gh pr diff ${{ github.event.pull_request.number }}
+            ```
+
+            Then review using the code-reviewer agent guidelines in `.claude/agents/code-reviewer.md`.
 
             IMPORTANT - Comment Management:
             There should only be ONE review comment from Claude at any time. Before leaving a comment:
@@ -51,5 +53,5 @@ jobs:
             3. If an existing comment is found, UPDATE it using: `gh api repos/${{ github.repository }}/issues/comments/{comment_id} -X PATCH -f body="<new review content>"`
             4. If no existing comment is found, create a new one using: `gh pr comment ${{ github.event.pull_request.number }} --body "<review content>"`
 
-          # Use Claude Opus 4.5 model with allowed tools for PR review
+          # Use code-reviewer agent with allowed tools for PR review
           claude_args: '--model claude-opus-4-5 --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary

- Update GitHub Action to use the code-reviewer agent guidelines instead of separate documentation
- Ensures consistent review behavior between local (`code-reviewer` agent) and CI environments
- Leverages confidence-based filtering (≥80) to reduce false positives in reviews

## Test plan

- [ ] Create a test PR and verify the code review action runs successfully
- [ ] Verify review comments follow the code-reviewer agent format with confidence scores
- [ ] Confirm comment management (update vs create) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)