### PR TITLE
chore(agents): change model from sonnet to inherit

### DIFF
--- a/.claude/agents/code-architect.md
+++ b/.claude/agents/code-architect.md
@@ -2,7 +2,7 @@
 name: code-architect
 description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
-model: sonnet
+model: inherit
 color: green
 ---
 

--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -2,7 +2,7 @@
 name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies to inform new development
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
-model: sonnet
+model: inherit
 color: yellow
 ---
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
-model: sonnet
+model: inherit
 color: red
 ---
 


### PR DESCRIPTION
## Summary
- Update code-architect, code-explorer, and code-reviewer agents to use 'inherit' model
- Allows agents to inherit model from parent context instead of hardcoded 'sonnet'
- Add missing newline at end of code-explorer.md and code-reviewer.md files

## Test plan
- [x] Verify agents work correctly with inherited model setting
- [x] Confirm no functional changes to agent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)