### PR TITLE
chore(vscode): exclude coverage output files from file explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "files.exclude": {
-    "tmp": true
+    "tmp": true,
+    "coverage_test.out": true,
+    "coverage.out": true
   },
   "go.lintOnSave": "workspace",
   "go.formatTool": "goimports",


### PR DESCRIPTION
## Summary
- Hide coverage.out and coverage_test.out files from VSCode file explorer
- Reduces clutter during local development when running tests with coverage

## Test plan
- [x] Verify coverage files no longer appear in VSCode file explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)